### PR TITLE
resurrect mbuf probe on OpenBSD + small tweaks

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -8,7 +8,6 @@ LORDER?=lorder
 TSORT?=tsort
 NROFF?=nroff
 RANLIB?=ranlib
-STRIP?=strip
 POD2MAN?=pod2man
 
 RRDDIR?=/usr/local

--- a/platform/NetBSD/sm_pf.c
+++ b/platform/NetBSD/sm_pf.c
@@ -99,7 +99,7 @@ void
 init_pf(struct stream *st)
 {
     if (pf_dev == -1) {
-        privinit_pf();
+        privinit_pf(void);
     }
 
     info("started module pf()");

--- a/platform/OpenBSD/conf.sh
+++ b/platform/OpenBSD/conf.sh
@@ -1,7 +1,3 @@
-case `grep -csq KERN_MBSTAT /usr/include/sys/sysctl.h` in
-1)	echo "#define HAS_KERN_MBSTAT	1" ;;
-0)	echo "#undef HAS_KERN_MBSTAT" ;;
-esac;
 case `grep -csq "ds_rxfer" /usr/include/sys/disk.h` in
 1)	echo "#define HAS_IO2	1" ;;
 0)	echo "#undef HAS_IO2" ;;

--- a/platform/OpenBSD/sm_mbuf.c
+++ b/platform/OpenBSD/sm_mbuf.c
@@ -39,26 +39,70 @@
 
 #include <errno.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "error.h"
 #include "symon.h"
 
-#ifndef HAS_KERN_MBSTAT
+/* pool info */
+static int mbpool_index = -1;
+static int mclpools_index[MCLPOOLS];
+static int mclpool_count = 0;
+static struct kinfo_pool mbpool;
+
+static int maxclusters;
+static int iter;
+
 void
 init_mbuf(struct stream *st)
 {
-    fatal("mbuf module requires system upgrade (sysctl.h/KERN_MBSTAT)");
-}
-int
-get_mbuf(char *symon_buf, int maxlen, struct stream *st)
-{
-    fatal("mbuf module requires system upgrade (sysctl.h/KERN_MBSTAT)");
-}
-#else
-void
-init_mbuf(struct stream *st)
-{
+    int i, mib[4], npools;
+    char pname[32];
+    size_t size;
+
+    /* go through all pools to identify mbuf and cluster pools */
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_POOL;
+    mib[2] = KERN_POOL_NPOOLS;
+    size = sizeof(npools);
+
+    if (sysctl(mib, 3, &npools, &size, NULL, 0) == -1)
+        fatal("mbuf: KERN_POOL_NPOOLS failed: %s", strerror(errno));
+
+    for (i = 1; i <= npools; i++) {
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_POOL;
+        mib[2] = KERN_POOL_NAME;
+        mib[3] = i;
+        size = sizeof(pname);
+        if (sysctl(mib, 4, &pname, &size, NULL, 0) == -1)
+            continue;
+
+        if (strcmp(pname, "mbufpl") == 0) {
+            mbpool_index = i;
+            continue;
+        }
+
+        if (strncmp(pname, "mcl", 3) != 0)
+            continue;
+
+        if (mclpool_count == MCLPOOLS) {
+            warning("mbuf: too many mcl* pools");
+            break;
+        }
+
+        mclpools_index[mclpool_count++] = i;
+    }
+
+    if (mclpool_count != MCLPOOLS)
+        warning("mbuf: unable to read all %d mcl* pools", MCLPOOLS);
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_MAXCLUSTERS;
+    size = sizeof(maxclusters);
+    if (sysctl(mib, 2, &maxclusters, &size, NULL, 0) == -1)
+        fatal("mbuf: KERN_MAXCLUSTERS failed: %s", strerror(errno));
+
     info("started module mbuf(%.200s)", st->arg);
 }
 
@@ -66,114 +110,68 @@ int
 get_mbuf(char *symon_buf, int maxlen, struct stream *st)
 {
     struct mbstat mbstat;
-    int npools;
-    struct kinfo_pool pool, mbpool, mclpool;
+    struct kinfo_pool pool;
     int mib[4];
     size_t size;
-    int i;
-    char name[32];
-    int flag = 0;
-    int nmbtypes = sizeof(mbstat.m_mtypes) / sizeof(mbstat.m_mtypes[0]);
-    int page_size = getpagesize();
-    int totmem, totused, totmbufs, totpct;
+    int nmbtypes = sizeof(mbstat.m_mtypes) / sizeof(long);
+    int i, totmem, totcnt, totalive, totmbufs, totpct;
     u_int32_t stats[15];
 
-    totmem = totused = 0;
-
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_MBSTAT;
-    size = sizeof(mbstat);
-    if (sysctl(mib, 2, &mbstat, &size, NULL, 0) < 0) {
-        warning("mbuf(%.200s) failed (sysctl() %.200s)", st->arg, strerror(errno));
-        return 0;
-    }
+    iter++;
 
     mib[0] = CTL_KERN;
     mib[1] = KERN_POOL;
-    mib[2] = KERN_POOL_NPOOLS;
-    size = sizeof(npools);
-    if (sysctl(mib, 3, &npools, &size, NULL, 0) < 0) {
-        warning("mbuf(%.200s) failed (sysctl() %.200s)", st->arg, strerror(errno));
+    mib[2] = KERN_POOL_POOL;
+    mib[3] = mbpool_index;
+    size = sizeof(mbpool);
+
+    if (sysctl(mib, 4, &mbpool, &size, NULL, 0) == -1) {
+        warning("mbuf: KERN_POOL_POOL mbufpl failed: %s", strerror(errno));
         return 0;
     }
+    totmem = mbpool.pr_npages * mbpool.pr_pgsize;
+    totcnt = mbpool.pr_npages * mbpool.pr_itemsperpage;
+    totalive = mbpool.pr_nget - mbpool.pr_nput;
 
-    for (i = 1; npools; ++i) {
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_POOL;
-        mib[2] = KERN_POOL_POOL;
-        mib[3] = i;
+    /* mbuf cluster counts */
+    for (i = 0; i < mclpool_count; i++) {
+        mib[3] = mclpools_index[i];
         size = sizeof(pool);
-        if (sysctl(mib, 4, &pool, &size, NULL, 0) < 0) {
-            warning("mbuf(%.200s) failed (sysctl() %.200s)", st->arg, strerror(errno));
-            return 0;
+
+        if (sysctl(mib, 4, &pool, &size, NULL, 0) == -1) {
+            warning("mbuf: KERN_POOL_POOL %d failed: %s", i, strerror(errno));
+            continue;
         }
-        npools--;
-        mib[2] = KERN_POOL_NAME;
-        size = sizeof(name);
-        if (sysctl(mib, 4, name, &size, NULL, 0) < 0) {
-            warning("mbuf(%.200s) failed (sysctl() %.200s)", st->arg, strerror(errno));
-            return (0);
-        }
-        if (!strcmp(name, "mbpl") || !strcmp(name, "mbufpl")) {
-            bcopy(&pool, &mbpool, sizeof(pool));
-            flag |= (1 << 0);
-        } else if (!strcmp(name, "mclpl")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 1);
-        } else if (!strcmp(name, "mcl2k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 2);
-        } else if (!strcmp(name, "mcl4k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 3);
-        } else if (!strcmp(name, "mcl8k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 4);
-        } else if (!strcmp(name, "mcl9k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 5);
-        } else if (!strcmp(name, "mcl12k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 6);
-        } else if (!strcmp(name, "mcl16k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 7);
-        } else if (!strcmp(name, "mcl64k")) {
-            bcopy(&pool, &mclpool, sizeof(pool));
-            totmem += mclpool.pr_npages * page_size;
-            totused += (mclpool.pr_nget - mclpool.pr_nput) * mclpool.pr_size;
-            flag |= (1 << 8);
-        }
-        if (flag == 3 || flag == 509)
-            break;
+
+        totmem += pool.pr_npages * pool.pr_pgsize;
+        totcnt += pool.pr_npages * pool.pr_itemsperpage;
+        totalive += pool.pr_nget - pool.pr_nput;
     }
 
-    /* Check pre/post h2k8 mcpl */
-    if ((flag != 3) && (flag != 509)) {
-        warning("mbuf(%.200s) failed (%d)", st->arg, flag);
+    /*
+     * No need to check for configuration changes everytime. Normally this code
+     * runs every 5 seconds and the system call is not completely free, so
+     * update once every 12 iterations.
+     */
+    if (iter % 12 == 0) {
+        mib[1] = KERN_MAXCLUSTERS;
+        size = sizeof(maxclusters);
+        if (sysctl(mib, 2, &maxclusters, &size, NULL, 0) == -1)
+            warning("mbuf: KERN_MAXCLUSTERS failed: %s", strerror(errno));
+    }
+
+    totpct = ((unsigned long)totmem * 100) / ((unsigned long)maxclusters * MCLBYTES);
+
+    mib[1] = KERN_MBSTAT;
+    size = sizeof(mbstat);
+    if (sysctl(mib, 2, &mbstat, &size, NULL, 0) == -1) {
+        warning("mbuf: KERN_MBSTAT failed: %s", strerror(errno));
         return 0;
     }
 
     totmbufs = 0;
     for (i = 0; i < nmbtypes; ++i)
         totmbufs += mbstat.m_mtypes[i];
-    totmem += mbpool.pr_npages * page_size;
-    totused += (mbpool.pr_nget - mbpool.pr_nput) * mbpool.pr_size;
-    totpct = (totmem == 0) ? 0 : ((totused * 100) / totmem);
 
     stats[0] = totmbufs;
     stats[1] = mbstat.m_mtypes[MT_DATA];
@@ -183,8 +181,8 @@ get_mbuf(char *symon_buf, int maxlen, struct stream *st)
     stats[5] = mbstat.m_mtypes[MT_FTABLE];
     stats[6] = mbstat.m_mtypes[MT_SONAME];
     stats[7] = mbstat.m_mtypes[MT_SOOPTS];
-    stats[8] = mclpool.pr_nget - mclpool.pr_nput;
-    stats[9] = mclpool.pr_npages * mclpool.pr_itemsperpage;
+    stats[8] = totalive;  /* pgused */
+    stats[9] = totcnt;    /* pgtotal */
     stats[10] = totmem;
     stats[11] = totpct;
     stats[12] = mbstat.m_drops;
@@ -208,4 +206,3 @@ get_mbuf(char *symon_buf, int maxlen, struct stream *st)
                   stats[13],
                   stats[14]);
 }
-#endif /* HAS_KERN_MBSTAT */

--- a/symon/Makefile
+++ b/symon/Makefile
@@ -22,9 +22,6 @@ ${OBJS}: conf.h
 
 symon: ${OBJS}
 	${CC} -o $@ ${OBJS} ${LIBS}
-.ifndef DEBUG
-	${STRIP} $@
-.endif
 
 clean:
 	rm -f conf.h symon symon.cat8 symon.core ${OBJS}

--- a/symux/Makefile
+++ b/symux/Makefile
@@ -11,9 +11,6 @@ all: symux symux.cat8
 
 symux: ${OBJS}
 	${CC} -o $@ ${OBJS} ${LIBS}
-.ifndef DEBUG
-	${STRIP} $@
-.endif
 
 clean:
 	rm -f conf.h symux symux.cat8 symux.core ${OBJS}


### PR DESCRIPTION
mbuf:
    * model after systat(1) mbufs
    * add missing cluster mcl2k2
    * big performance improvements
    * stricter sysctl error handling
    * remove ifdef KERN_MBSTAT (defined since OpenBSD 3.2)

other:
    * fix function declarations without prototype
    * don't strip executables