### PR TITLE
OpenBSD io: remove ifdef HAS_IO2

### DIFF
--- a/platform/OpenBSD/conf.sh
+++ b/platform/OpenBSD/conf.sh
@@ -2,10 +2,6 @@ case `grep -csq KERN_MBSTAT /usr/include/sys/sysctl.h` in
 1)	echo "#define HAS_KERN_MBSTAT	1" ;;
 0)	echo "#undef HAS_KERN_MBSTAT" ;;
 esac;
-case `grep -csq "ds_rxfer" /usr/include/sys/disk.h` in
-1)	echo "#define HAS_IO2	1" ;;
-0)	echo "#undef HAS_IO2" ;;
-esac;
 if [ -f /usr/include/net/pfvar.h ]; then
     echo "#define HAS_PFVAR_H	1"
 else

--- a/platform/OpenBSD/sm_io.c
+++ b/platform/OpenBSD/sm_io.c
@@ -158,19 +158,12 @@ get_io(char *symon_buf, int maxlen, struct stream *st)
                     (io_dkstr + io_maxstr - io_dknames[i])) == 0)
         	    || (io_dkuids[i] && (strncmp(io_dkuids[i], st->arg,
                     (io_dkstr + io_maxstr - io_dkuids[i])) == 0)))
-#ifdef HAS_IO2
             return snpack(symon_buf, maxlen, st->arg, MT_IO2,
                           io_dkstats[i].ds_rxfer,
                           io_dkstats[i].ds_wxfer,
                           io_dkstats[i].ds_seek,
                           io_dkstats[i].ds_rbytes,
                           io_dkstats[i].ds_wbytes);
-#else
-            return snpack(symon_buf, maxlen, st->arg, MT_IO1,
-                          io_dkstats[i].ds_xfer,
-                          io_dkstats[i].ds_seek,
-                          io_dkstats[i].ds_bytes);
-#endif
     }
 
     return 0;


### PR DESCRIPTION
Depends on code that was introduced in OpenBSD 3.5 which was released in 2004.