### PR TITLE
let symux get fifo as the superuser and drop privileges

### DIFF
--- a/platform/FreeBSD/platform.h
+++ b/platform/FreeBSD/platform.h
@@ -15,6 +15,7 @@
 #include "sylimits.h"
 
 #define SYMON_USER      "_symon"
+#define SYMUX_USER      "_symux"
 #define SA_LEN(x)       ((x)->sa_len)
 #define SS_LEN(x)       ((x)->ss_len)
 

--- a/platform/Linux/platform.h
+++ b/platform/Linux/platform.h
@@ -14,6 +14,7 @@
 #include "sylimits.h"
 
 #define SYMON_USER      "symon"
+#define SYMUX_USER      "symux"
 #define SA_LEN(x)       (((x)->sa_family == AF_INET6) ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in))
 #define SS_LEN(x)       (((x)->ss_family == AF_INET6) ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in))
 

--- a/platform/NetBSD/platform.h
+++ b/platform/NetBSD/platform.h
@@ -15,6 +15,7 @@
 #include "sylimits.h"
 
 #define SYMON_USER      "_symon"
+#define SYMUX_USER      "_symux"
 #define SA_LEN(x)       ((x)->sa_len)
 #define SS_LEN(x)       ((x)->ss_len)
 

--- a/platform/OpenBSD/platform.h
+++ b/platform/OpenBSD/platform.h
@@ -15,6 +15,7 @@
 #include "sylimits.h"
 
 #define SYMON_USER      "_symon"
+#define SYMUX_USER      "_symux"
 #define SA_LEN(x)       ((x)->sa_len)
 #define SS_LEN(x)       ((x)->ss_len)
 


### PR DESCRIPTION
This fixes the following issue on OpenBSD when started as user _symux:
`fatal: cannot create fifo /var/run/symux.fifo for reporting; Permission denied`

Note: daemon_user=_symux should be removed from /etc/rc.d/symux so that it's started as the superuser.