### PR TITLE
new time probe

### DIFF
--- a/lib/data.c
+++ b/lib/data.c
@@ -112,6 +112,7 @@ struct {
     { MT_LOAD, "ccc" },
     { MT_FLUKSO, "D" },
     { MT_WG, "LLl" },
+    { MT_TIME, "l" },
     { MT_TEST, "LLLLDDDDllllssssccccbbbb" },
     { MT_EOT, "" }
 };
@@ -139,6 +140,7 @@ struct {
     { MT_LOAD, LXT_LOAD },
     { MT_FLUKSO, LXT_FLUKSO },
     { MT_WG, LXT_WG },
+    { MT_TIME, LXT_TIME },
     { MT_EOT, LXT_BADTOKEN }
 };
 /* parallel crc32 table */

--- a/lib/data.h
+++ b/lib/data.h
@@ -164,8 +164,9 @@ SLIST_HEAD(muxlist, mux);
 #define MT_LOAD   16
 #define MT_FLUKSO 17
 #define MT_WG     18
-#define MT_TEST   19
-#define MT_EOT    20
+#define MT_TIME   19
+#define MT_TEST   20
+#define MT_EOT    21
 
 /*
  * Unpacking of incoming packets is done via a packedstream structure. This
@@ -359,6 +360,9 @@ struct packedstream {
             u_int64_t txbytes;
             u_int32_t lasthandshake;
         }      ps_wg;
+        struct {
+            u_int32_t usec;
+        }      ps_time;
     }     data;
 };
 

--- a/lib/lex.c
+++ b/lib/lex.c
@@ -100,6 +100,7 @@ static struct {
     { "smart", LXT_SMART },
     { "source", LXT_SOURCE },
     { "stream", LXT_STREAM },
+    { "time", LXT_TIME },
     { "to", LXT_TO },
     { "wg", LXT_WG },
     { "write", LXT_WRITE },

--- a/lib/lex.h
+++ b/lib/lex.h
@@ -75,9 +75,10 @@
 #define LXT_SMART     33
 #define LXT_SOURCE    34
 #define LXT_STREAM    35
-#define LXT_TO        36
-#define LXT_WG        37
-#define LXT_WRITE     38
+#define LXT_TIME      36
+#define LXT_TO        37
+#define LXT_WG        38
+#define LXT_WRITE     39
 
 struct lex {
     char *buffer;               /* current line(s) */

--- a/platform/generic/sm_time.c
+++ b/platform/generic/sm_time.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Tim Kuijsten
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    - Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+
+#define _XOPEN_SOURCE 600
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+#include "error.h"
+#include "symon.h"
+
+static struct timespec prevtime, curtime;
+static int initialized;
+
+void
+init_time(struct stream *st)
+{
+	if (initialized == 1)
+		fatal("time module can be configured only once");
+
+	initialized = 1;
+
+	info("started module time()");
+}
+
+int
+get_time(char *symon_buf, int maxlen, struct stream *st)
+{
+	uint32_t diff;
+
+	prevtime = curtime;
+	if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &curtime) == -1)
+		fatal("time: clock_gettime: %s", strerror(errno));
+
+	if (prevtime.tv_sec == 0 && prevtime.tv_nsec == 0)
+		return 0; /* wait before we have a measurement */
+
+	diff = curtime.tv_sec - prevtime.tv_sec;
+	diff *= 1000000U;
+	diff += (curtime.tv_nsec  + 500) / 1000;
+	diff -= (prevtime.tv_nsec + 500) / 1000;
+
+	return snpack(symon_buf, maxlen, st->arg, MT_TIME, diff);
+}

--- a/platform/stub/sm_time.c
+++ b/platform/stub/sm_time.c
@@ -1,0 +1,17 @@
+#include "error.h"
+#include "symon.h"
+
+void
+init_time(struct stream *st)
+{
+    fatal("time module not available");
+}
+
+int
+get_time(char *symon_buf, int maxlen, struct stream *st)
+{
+    fatal("time module not available");
+
+    /* NOT REACHED */
+    return 0;
+}

--- a/symon/readconf.c
+++ b/symon/readconf.c
@@ -115,6 +115,7 @@ read_symon_args(struct mux * mux, struct lex * l)
         case LXT_SMART:
         case LXT_LOAD:
         case LXT_FLUKSO:
+        case LXT_TIME:
         case LXT_WG:
             st = token2type(l->op);
             strncpy(&sn[0], l->token, (_POSIX2_LINE_MAX - 1));
@@ -154,7 +155,7 @@ read_symon_args(struct mux * mux, struct lex * l)
         case LXT_COMMA:
             break;
         default:
-            parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|load|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso|wg}");
+            parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|load|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso|wg|time}");
             return 0;
             break;
         }

--- a/symon/symon.c
+++ b/symon/symon.c
@@ -88,6 +88,7 @@ struct funcmap streamfunc[] = {
     {MT_LOAD, 0, NULL, init_load, gets_load, get_load},
     {MT_FLUKSO, 0, NULL, init_flukso, gets_flukso, get_flukso},
     {MT_WG, 0, NULL, init_wg, gets_wg, get_wg},
+    {MT_TIME, 0, NULL, init_time, NULL, get_time},
     {MT_EOT, 0, NULL, NULL, NULL, NULL}
 };
 

--- a/symon/symon.h
+++ b/symon/symon.h
@@ -141,4 +141,8 @@ extern void init_wg(struct stream *);
 extern void gets_wg(void);
 extern int get_wg(char *, int, struct stream *);
 
+/* sm_time.c */
+extern void init_time(struct stream *);
+extern int get_time(char *, int, struct stream *);
+
 #endif                          /* _SYMON_SYMON_H */

--- a/symux/c_smrrds.sh
+++ b/symux/c_smrrds.sh
@@ -312,6 +312,12 @@ smart_*.rrd)
         DS:freefall:GAUGE:$INTERVAL:U:U
     ;;
 
+time.rrd)
+    # Build symon cpu time file
+    create_rrd $i \
+	DS:usec:GAUGE:$INTERVAL:0:U
+    ;;
+
 load.rrd)
     # Build load file
     create_rrd $i \

--- a/symux/readconf.c
+++ b/symux/readconf.c
@@ -118,6 +118,10 @@ insert_filename(char *path, int maxlen, int type, char *args)
         ts = "smart_";
         ta = args;
         break;
+    case MT_TIME:
+        ts = "time";
+        ta = "";
+        break;
     case MT_LOAD:
         ts = "load";
         ta = "";
@@ -247,6 +251,7 @@ read_source(struct sourcelist * sol, struct lex * l, int filecheck)
                 case LXT_SMART:
                 case LXT_LOAD:
                 case LXT_FLUKSO:
+                case LXT_TIME:
                 case LXT_WG:
                     st = token2type(l->op);
                     strncpy(&sn[0], l->token, (_POSIX2_LINE_MAX - 1));
@@ -289,7 +294,7 @@ read_source(struct sourcelist * sol, struct lex * l, int filecheck)
                 case LXT_COMMA:
                     break;
                 default:
-                    parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso|wg}");
+                    parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso|wg|time}");
                     return 0;
 
                     break;


### PR DESCRIPTION
This new time probe allows for finer grained performance metrics than the existing proc probe. This comes in handy while optimizing or tracking the performance of existing probes and symon(8) as a whole.

I have chosen a 32 bit packed format to send out the number of microseconds symon used compared to the previous poll. This allows for expressing at most 4,2 seconds of cpu time per 5 second interval and thus might wrap. But symon should be well under this threshold and not take that much cpu time to run.

Tested on OpenBSD and Debian 11.