### PR TITLE
OpenBSD: new WireGuard peer probe

### DIFF
--- a/lib/data.c
+++ b/lib/data.c
@@ -111,6 +111,7 @@ struct {
     { MT_SMART, "bbbbbbbbbbbb" },
     { MT_LOAD, "ccc" },
     { MT_FLUKSO, "D" },
+    { MT_WG, "LLl" },
     { MT_TEST, "LLLLDDDDllllssssccccbbbb" },
     { MT_EOT, "" }
 };
@@ -137,6 +138,7 @@ struct {
     { MT_SMART, LXT_SMART },
     { MT_LOAD, LXT_LOAD },
     { MT_FLUKSO, LXT_FLUKSO },
+    { MT_WG, LXT_WG },
     { MT_EOT, LXT_BADTOKEN }
 };
 /* parallel crc32 table */

--- a/lib/data.h
+++ b/lib/data.h
@@ -163,8 +163,9 @@ SLIST_HEAD(muxlist, mux);
 #define MT_SMART  15
 #define MT_LOAD   16
 #define MT_FLUKSO 17
-#define MT_TEST   18
-#define MT_EOT    19
+#define MT_WG     18
+#define MT_TEST   19
+#define MT_EOT    20
 
 /*
  * Unpacking of incoming packets is done via a packedstream structure. This
@@ -353,6 +354,11 @@ struct packedstream {
         struct {
             int64_t value;
         }      ps_flukso;
+        struct {
+            u_int64_t rxbytes;
+            u_int64_t txbytes;
+            u_int32_t lasthandshake;
+        }      ps_wg;
     }     data;
 };
 

--- a/lib/lex.c
+++ b/lib/lex.c
@@ -101,6 +101,7 @@ static struct {
     { "source", LXT_SOURCE },
     { "stream", LXT_STREAM },
     { "to", LXT_TO },
+    { "wg", LXT_WG },
     { "write", LXT_WRITE },
     { NULL, 0 }
 };

--- a/lib/lex.h
+++ b/lib/lex.h
@@ -76,7 +76,8 @@
 #define LXT_SOURCE    34
 #define LXT_STREAM    35
 #define LXT_TO        36
-#define LXT_WRITE     37
+#define LXT_WG        37
+#define LXT_WRITE     38
 
 struct lex {
     char *buffer;               /* current line(s) */

--- a/lib/sylimits.h
+++ b/lib/sylimits.h
@@ -14,6 +14,7 @@
 #define SYMON_DFBLOCKSIZE      512
 #define SYMON_DFNAMESIZE       64
 #define SYMON_MAXPACKET        65515    /* udp packet max payload 65Kb - 20 byte header */
+#define SYMON_WGPEERDESC       IFDESCRSIZE	/* maximum wireguard peer description */
 
 #define SYMON_MAXLEXNUM        65535    /* maximum numeric argument while lexing */
 #endif

--- a/platform/OpenBSD/platform.h
+++ b/platform/OpenBSD/platform.h
@@ -38,6 +38,10 @@ union stream_parg {
         int mib[5];
     } sn;
     int smart;
+    struct {
+	char full[IFNAMSIZ + 1 + SYMON_WGPEERDESC];
+	char *peerdesc;
+    } wg;
 };
 
 #endif

--- a/platform/OpenBSD/sm_wg.c
+++ b/platform/OpenBSD/sm_wg.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2024 Tim Kuijsten
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    - Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Get the current WireGuard peer statistics from the kernel and return them in
+ * symon_buf as
+ *
+ * total bytes received : total bytes transmitted : last handshake
+ */
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include <net/if.h>
+#include <net/if_wg.h>
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "conf.h"
+#include "error.h"
+#include "errno.h"
+#include "symon.h"
+#include "xmalloc.h"
+
+static struct wg_data_io *wg_stats;
+static size_t wg_stats_count;
+static int sock = -1;
+
+void
+init_wg(struct stream *st)
+{
+	struct wg_data_io      *wgdata;
+	char *peerdesc;
+	size_t i;
+
+	if (geteuid() != 0) {
+		warning("%s requires symon to run as the superuser, use -u",
+			st->arg);
+		return;
+	}
+
+	/* split arg on interface and peer name */
+	if (strlcpy(st->parg.wg.full, st->arg, sizeof(st->parg.wg.full))
+	    >= sizeof(st->parg.wg.full))
+		fatal("interface name plus peer description exceed %d bytes: %s",
+		    sizeof(st->parg.wg.full), st->arg);
+
+	peerdesc = strchr(st->arg, '-');
+	if (peerdesc == NULL)
+		fatal("could not find dash between interface name and peer description: %s",
+		    st->arg);
+
+	*peerdesc = '\0';
+	peerdesc++;
+	if (strlen(peerdesc) == 0)
+		fatal("peer description empty: %s", st->parg.wg.full);
+
+	if (strlen(peerdesc) > SYMON_WGPEERDESC)
+		fatal("peer description exceeds %d characters: %s",
+			SYMON_WGPEERDESC, peerdesc);
+
+	st->parg.wg.peerdesc = peerdesc;
+
+	if (sock == -1) {
+		sock = socket(AF_INET, SOCK_DGRAM, 0);
+		if (sock == -1)
+			fatal("socket");
+	}
+
+	wgdata = NULL;
+	for (i = 0; i < wg_stats_count; i++) {
+		if (strcmp(wg_stats[i].wgd_name, st->arg) == 0) {
+			wgdata = &wg_stats[i];
+			break;
+		}
+	}
+
+	if (wgdata == NULL) {
+		wg_stats = xreallocarray(wg_stats, wg_stats_count + 1,
+		    sizeof(*wg_stats));
+		wgdata = &wg_stats[wg_stats_count];
+		strlcpy(wgdata->wgd_name, st->arg, sizeof(wgdata->wgd_name));
+		wgdata->wgd_size = 0;
+		wgdata->wgd_interface = NULL;
+		wg_stats_count++;
+	}
+
+	info("started module wg(%.200s)", st->parg.wg.full);
+}
+
+void
+gets_wg(void)
+{
+	struct wg_data_io *wgdata;
+	struct wg_interface_io *p;
+	size_t i, last_size;
+
+	for (i = 0; i < wg_stats_count; i++) {
+		wgdata = &wg_stats[i];
+		for (;;) {
+			last_size = wgdata->wgd_size;
+			if (ioctl(sock, SIOCGWG, wgdata) == -1) {
+				if (errno != ENXIO)
+					warning("%s: SIOCGWG: %s",
+					    wgdata->wgd_name, strerror(errno));
+				break;
+			}
+
+			if (last_size >= wgdata->wgd_size)
+				break;
+
+			if (wgdata->wgd_size > SYMON_MAX_DOBJECTS) {
+				warning("%s:%d: dynamic object limit (%d) "
+				    "exceeded for wg_data_io structure",
+				    __FILE__, __LINE__, SYMON_MAX_DOBJECTS);
+				free(wgdata->wgd_interface);
+				wgdata->wgd_interface = NULL;
+				wgdata->wgd_size = 0;
+				break;
+			}
+
+			p = realloc(wgdata->wgd_interface, wgdata->wgd_size);
+			if (p == NULL) {
+				warning("wg %s: could not allocate memory: %s",
+				    wgdata->wgd_name, wgdata->wgd_size,
+				    strerror(errno));
+				free(wgdata->wgd_interface);
+				wgdata->wgd_interface = NULL;
+				wgdata->wgd_size = 0;
+				break;
+			}
+
+			wgdata->wgd_interface = p;
+		}
+	}
+}
+
+int
+get_wg(char *symon_buf, int maxlen, struct stream *st)
+{
+	struct wg_interface_io *wg_interface;
+	struct wg_peer_io      *wg_peer;
+	struct wg_aip_io       *wg_aip;
+	size_t i;
+
+	wg_interface = NULL;
+	for (i = 0; i < wg_stats_count; i++) {
+		if (strcmp(wg_stats[i].wgd_name, st->arg) == 0) {
+			wg_interface = wg_stats[i].wgd_interface;
+			break;
+		}
+	}
+
+	if (wg_interface == NULL)
+		return 0;
+
+	wg_peer = &wg_interface->i_peers[0];
+	for (i = 0; i < wg_interface->i_peers_count; i++) {
+		if (strcmp(wg_peer->p_description, st->parg.wg.peerdesc) != 0) {
+			wg_aip = &wg_peer->p_aips[0];
+			wg_aip += wg_peer->p_aips_count;
+			wg_peer = (struct wg_peer_io *)wg_aip;
+			continue;
+		}
+
+		return snpack(symon_buf, maxlen, st->parg.wg.full, MT_WG,
+		    wg_peer->p_rxbytes,
+		    wg_peer->p_txbytes,
+		    wg_peer->p_last_handshake.tv_sec);
+	}
+
+	debug("couldn't find peer with description \"%s\" on %s", st->parg.wg.peerdesc,
+	    st->arg);
+
+	return 0;
+}

--- a/platform/stub/sm_wg.c
+++ b/platform/stub/sm_wg.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+
+#include "sylimits.h"
+#include "data.h"
+#include "error.h"
+
+void
+init_wg(struct stream *st)
+{
+    fatal("wg module not available");
+}
+void
+gets_wg()
+{
+    fatal("wg module not available");
+}
+int
+get_wg(char *symon_buf, int maxlen, struct stream *st)
+{
+    fatal("wg module not available");
+
+    /* NOT REACHED */
+    return 0;
+}

--- a/symon/readconf.c
+++ b/symon/readconf.c
@@ -115,6 +115,7 @@ read_symon_args(struct mux * mux, struct lex * l)
         case LXT_SMART:
         case LXT_LOAD:
         case LXT_FLUKSO:
+        case LXT_WG:
             st = token2type(l->op);
             strncpy(&sn[0], l->token, (_POSIX2_LINE_MAX - 1));
 
@@ -153,7 +154,7 @@ read_symon_args(struct mux * mux, struct lex * l)
         case LXT_COMMA:
             break;
         default:
-            parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|load|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso}");
+            parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|load|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso|wg}");
             return 0;
             break;
         }

--- a/symon/symon.c
+++ b/symon/symon.c
@@ -87,6 +87,7 @@ struct funcmap streamfunc[] = {
     {MT_SMART, 0, privinit_smart, init_smart, gets_smart, get_smart},
     {MT_LOAD, 0, NULL, init_load, gets_load, get_load},
     {MT_FLUKSO, 0, NULL, init_flukso, gets_flukso, get_flukso},
+    {MT_WG, 0, NULL, init_wg, gets_wg, get_wg},
     {MT_EOT, 0, NULL, NULL, NULL, NULL}
 };
 

--- a/symon/symon.h
+++ b/symon/symon.h
@@ -136,5 +136,9 @@ void init_flukso(struct stream *);
 void gets_flukso(void);
 int get_flukso(char *, int, struct stream *);
 
+/* sm_wg.c */
+extern void init_wg(struct stream *);
+extern void gets_wg(void);
+extern int get_wg(char *, int, struct stream *);
 
 #endif                          /* _SYMON_SYMON_H */

--- a/symux/c_smrrds.sh
+++ b/symux/c_smrrds.sh
@@ -326,6 +326,14 @@ flukso_*.rrd)
         DS:watts:GAUGE:$INTERVAL:0:U
     ;;
 
+wg_*.rrd)
+    # Build wireguard files
+    create_rrd $i \
+	DS:rxbytes:COUNTER:$INTERVAL:0:U \
+	DS:txbytes:COUNTER:$INTERVAL:0:U \
+	DS:lasthandshake:COUNTER:$INTERVAL:0:U
+    ;;
+
 "done")
     # ignore
     ;;

--- a/symux/readconf.c
+++ b/symux/readconf.c
@@ -126,6 +126,10 @@ insert_filename(char *path, int maxlen, int type, char *args)
         ts = "flukso_";
         ta = args;
         break;
+    case MT_WG:
+        ts = "wg_";
+        ta = args;
+        break;
 
     default:
         warning("%.200s:%d: internal error: type (%d) unknown",
@@ -243,6 +247,7 @@ read_source(struct sourcelist * sol, struct lex * l, int filecheck)
                 case LXT_SMART:
                 case LXT_LOAD:
                 case LXT_FLUKSO:
+                case LXT_WG:
                     st = token2type(l->op);
                     strncpy(&sn[0], l->token, (_POSIX2_LINE_MAX - 1));
 
@@ -284,7 +289,7 @@ read_source(struct sourcelist * sol, struct lex * l, int filecheck)
                 case LXT_COMMA:
                     break;
                 default:
-                    parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso}");
+                    parse_error(l, "{cpu|cpuiow|df|if|if1|io|io1|mem|mem1|pf|pfq|mbuf|debug|proc|sensor|smart|load|flukso|wg}");
                     return 0;
 
                     break;
@@ -389,6 +394,7 @@ read_source(struct sourcelist * sol, struct lex * l, int filecheck)
             case LXT_SMART:
             case LXT_LOAD:
             case LXT_FLUKSO:
+            case LXT_WG:
                 st = token2type(l->op);
                 strncpy(&sn[0], l->token, (_POSIX2_LINE_MAX - 1));
 

--- a/symux/symux.8
+++ b/symux/symux.8
@@ -119,7 +119,7 @@ resources    = resource [ version ] ["(" argument ")"]
                [ ","|" " resources ]
 resource     = "cpu" | "cpuiow" | "debug" | "df" | "flukso" |
                "if" | "io" | "load" | "mbuf" | "mem" | "pf" |
-               "pfq" | "proc" | "sensor" | "smart"
+               "pfq" | "proc" | "sensor" | "smart" | "wg"
 version      = number
 argument     = number | interfacename | diskname
 datadir-stmt = "datadir" dirname
@@ -281,6 +281,10 @@ soft_read_error_rate: g_sense_error_rate: temperature2: free_fall_protection
 Average pwr sensor value offered with 7.6 precision. Value is a moving average
 and will depend on the number of measurements seen in a particular symon
 interval.
+.It wg
+WireGuard peer counters ( rxbytes : txbytes : lasthandshake ).
+rxbytes and txbytes are 64 bit unsigned integers.
+lasthandshake is a 32 bit unsigned integer.
 .El
 .Sh SIGNALS
 .Bl -tag -width Ds


### PR DESCRIPTION
Track the number of bytes received and sent and the last handshake per peer by peer description.

Config syntax: wg(wg1:foo) for a peer on wg1 that has description "foo".