### PR TITLE
unveil datadir instead of individual files if datadir is set

### DIFF
--- a/lib/data.h
+++ b/lib/data.h
@@ -112,6 +112,7 @@ SLIST_HEAD(streamlist, stream);
 
 struct source {
     char *addr;
+    char *datadir;
     struct sockaddr_storage sockaddr;
     struct streamlist sl;
     SLIST_ENTRY(source) sources;

--- a/symux/readconf.c
+++ b/symux/readconf.c
@@ -338,6 +338,8 @@ read_source(struct sourcelist * sol, struct lex * l, int filecheck)
                 pc--;
             }
 
+            source->datadir = xstrdup(path);
+
             /* add path to empty streams */
             SLIST_FOREACH(stream, &source->sl, streams) {
                 if (stream->file == NULL) {

--- a/symux/symux.c
+++ b/symux/symux.c
@@ -289,7 +289,10 @@ main(int argc, char *argv[])
 
 #ifdef HAS_UNVEIL
     SLIST_FOREACH(source, &mux->sol, sources) {
-        if (! SLIST_EMPTY(&source->sl)) {
+        if (source->datadir != NULL) {
+            if (unveil(source->datadir, "rw") == -1)
+                fatal("unveil %s: %.200s", source->datadir, strerror(errno));
+        } else if (! SLIST_EMPTY(&source->sl)) {
             SLIST_FOREACH(stream, &source->sl, streams) {
                 if (stream->file != NULL) {
                     if (unveil(stream->file, "rw") == -1)


### PR DESCRIPTION
Don't unveil every individual file for every probe, but simply unveil the datadir if this is set.

This fixes an issue in which unveil(2) fails because the argument list is too long. This can happen with a couple of sources and many probes.